### PR TITLE
Check exact storage for Dimension table in Cube Select Queries

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/cube/parse/CubeQueryContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cube/parse/CubeQueryContext.java
@@ -1134,7 +1134,10 @@ public class CubeQueryContext {
   }
 
   public boolean hasPartitions() {
-    return !dimStorageTableToWhereClause.isEmpty();
+    // Check if the resolved storage table in where clause has partition
+    AbstractCubeTable cube = storageTableToQuery.keySet().iterator().next();
+    return dimStorageTableToWhereClause.get(
+        storageTableToQuery.get(cube).iterator().next()) != null;
   }
 
   public Map<String, List<String>> getTblToColumns() {


### PR DESCRIPTION
Modify haspartition() to check partition in resolved storage table instead of relying on dimStorageTableToWhereClause
