### PR TITLE
Fixing Cube Storage Resolver To return Empty String in Case of Non Supported storage

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/cube/parse/StorageTableResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cube/parse/StorageTableResolver.java
@@ -218,7 +218,7 @@ public class StorageTableResolver implements ContextRewriter {
           skipStorageCauses.put(storage, SkipStorageCause.UNSUPPORTED);
         }
       }
-      if (dimStorageMap.get(dim).isEmpty()) {
+      if (dimStorageMap.get(dim) == null || dimStorageMap.get(dim).isEmpty()) {
         String reason = "";
         CandidateTablePruneCause cause = new CandidateTablePruneCause(
             dim.getName(), skipStorageCauses);


### PR DESCRIPTION
Please review the patch.
