### PR TITLE
Changes for protoc versio control and hbase storage handler proto changes in pom

### DIFF
--- a/hcatalog/storage-handlers/hbase/pom.xml
+++ b/hcatalog/storage-handlers/hbase/pom.xml
@@ -260,6 +260,39 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>protobuf</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-protobuf-sources</id>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <property name="protobuf.src.dir" location="${basedir}/src/protobuf" />
+                    <property name="protobuf.build.dir" location="${basedir}/src/gen-java" />
+                    <echo>Building Hcatalog Hbase Handler Protobuf</echo>
+                    <mkdir dir="${protobuf.build.dir}" />
+                    <exec executable="${protobuf.exec.path}" failonerror="true">
+                      <arg value="--java_out=${protobuf.build.dir}" />
+                      <arg value="-I=${protobuf.src.dir}/org/apache/hcatalog/hbase/snapshot/" />
+                      <arg value="${protobuf.src.dir}/org/apache/hcatalog/hbase/snapshot/RevisionManagerEndpoint.proto" />
+                    </exec>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
     <parquet.version>1.3.2</parquet.version>
     <pig.version>0.12.0</pig.version>
     <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.exec.path>protoc</protobuf.exec.path>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.5</slf4j.version>
     <ST4.version>4.0.4</ST4.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -406,7 +406,7 @@
                     <property name="protobuf.build.dir" location="${basedir}/src/gen/protobuf/gen-java" />
                     <echo>Building ORC Protobuf</echo>
                     <mkdir dir="${protobuf.build.dir}" />
-                    <exec executable="protoc" failonerror="true">
+                    <exec executable="${protobuf.exec.path}" failonerror="true">
                       <arg value="--java_out=${protobuf.build.dir}" />
                       <arg value="-I=${protobuf.src.dir}/org/apache/hadoop/hive/ql/io/orc" />
                       <arg value="${protobuf.src.dir}/org/apache/hadoop/hive/ql/io/orc/orc_proto.proto" />


### PR DESCRIPTION
Jersey needs to be changed to have the following in build conf

  mvn -Dprotobuf.version=2.4.1 clean package -Phadoop-1,protobuf,dist for CDH4

  mvn -Dmaven.test.failure.ignore=true  -o clean package -Phadoop-2,protobuf,dist for >= CDH5 
